### PR TITLE
Fixed the ‘Invalid Date’ issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.4] - 2019-6-30
+## [0.1.5] - 2019-07-13
+
+### Fixed
+
+- A bug where `Invalid Date` would be returned by the ping function if the Onewheel server was rate-limiting requests
+- An issue with npm package type definitions not being read correctly
+
+## [0.1.4] - 2019-06-30
 
 ### Changed
 
 - Removed `s from message commands
 
-## [0.1.3] - 2019-6-30
+## [0.1.3] - 2019-06-30
 
 ### Added
 
 - Note in welcome message about the help command
 
-## [0.1.2] - 2019-6-30
+## [0.1.2] - 2019-06-30
 
 ### Changed
 
@@ -35,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A bug where messages with excess spaces would not be sent the right responses
 
-## [0.1.1] - 2019-6-30
+## [0.1.1] - 2019-06-30
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onewheel-pinger",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "scripts": {
     "start": "ts-node index.ts",
     "test": "jest --watch",

--- a/src/ping.ts
+++ b/src/ping.ts
@@ -19,7 +19,9 @@ let ipAddress = '10.0.0.0'
 function incrementIpAddress () {
   const currentLastDigit = +ipAddress.split('.')[3]
   const nextDigit = (currentLastDigit + 1) % 255
-  return `10.0.0.${nextDigit}`
+  const nextIpAddress = `10.0.0.${nextDigit}`
+  ipAddress = nextIpAddress
+  return ipAddress
 }
 
 async function ping (order: number, email: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
+    "moduleResolution": "node",
     "target": "es2015"
   }
 }


### PR DESCRIPTION
### Fixed

- A bug where `Invalid Date` would be returned by the ping function if the Onewheel server was rate-limiting requests
- An issue with npm package type definitions not being read correctly