### PR TITLE
Moved @types development dependencies to dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9] - 2019-07-14
+
+### Changed
+
+- Moved `@types` development dependencies to dependencies since code is not compiled
+
 ## [0.1.8] - 2019-07-14
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onewheel-pinger",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "scripts": {
     "start": "ts-node index.ts",
     "test": "jest --watch",
@@ -24,6 +24,16 @@
   "author": "jdtzmn <jdtzmn@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "@types/body-parser": "^1.17.0",
+    "@types/cron": "^1.7.1",
+    "@types/debug": "^4.1.4",
+    "@types/dotenv": "^6.1.1",
+    "@types/express": "^4.17.0",
+    "@types/jest": "^24.0.15",
+    "@types/mongodb": "^3.1.28",
+    "@types/node": "^12.0.10",
+    "@typescript-eslint/eslint-plugin": "^1.11.0",
+    "@typescript-eslint/parser": "^1.11.0",
     "axios": "^0.19.0",
     "body-parser": "^1.19.0",
     "cron": "^1.7.1",
@@ -36,16 +46,6 @@
     "typescript": "^3.5.2"
   },
   "devDependencies": {
-    "@types/body-parser": "^1.17.0",
-    "@types/cron": "^1.7.1",
-    "@types/debug": "^4.1.4",
-    "@types/dotenv": "^6.1.1",
-    "@types/express": "^4.17.0",
-    "@types/jest": "^24.0.15",
-    "@types/mongodb": "^3.1.28",
-    "@types/node": "^12.0.10",
-    "@typescript-eslint/eslint-plugin": "^1.11.0",
-    "@typescript-eslint/parser": "^1.11.0",
     "eslint": "^6.0.1",
     "eslint-config-standard-with-typescript": "^7.1.0",
     "eslint-plugin-import": "^2.18.0",


### PR DESCRIPTION
### Changed

- Moved `@types` development dependencies to dependencies since code is not compiled